### PR TITLE
Fix typo 'abandonned'

### DIFF
--- a/0.5/unstable/apptest/src/classes/org/jdesktop/wonderland/modules/apptest/client/AppLauncher.java
+++ b/0.5/unstable/apptest/src/classes/org/jdesktop/wonderland/modules/apptest/client/AppLauncher.java
@@ -70,7 +70,7 @@ public class AppLauncher implements Runnable{
             logger.warning("AppLauncher for app " + app.getDisplayName()  + ": App launch " + 
                            (++numLaunches));
 
-            // Wait until app is stopped or the launch attempt is abandonned.
+            // Wait until app is stopped or the launch attempt is abandoned.
             while (!testStopped && appIsRunning) {
                 synchronized (this) {
                     try {


### PR DESCRIPTION
Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'abandoned', you typed 'abandonned'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
